### PR TITLE
Hotfix responsive button

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,14 +38,6 @@
                 >Zur Abstimmung</a
               >
             </div>
-            <div
-              class="absolute right-0 bg-white rounded-full flex justify-center items-center p-5 border-4 border-yellow-500"
-            >
-              <img
-                class="w-16 h-16 rounded-full"
-                src="./assets/img/angle.png"
-              />
-            </div>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -25,16 +25,17 @@
             es noch heute!
           </p>
           <div class="relative mt-4 flex">
-            <div>
+            <!--BUTTON WRAPPER-->
+            <dic class="flex flex-col sm:flex-row">
               <a
                 href="./eudentity.html"
                 class="bg-yellow-500 text-yellow-900 font-bold mt-2 px-4 py-2 rounded-full text-xs uppercase"
-                >Bestellen</a
+                >Jetzt Bestellen</a
               >
                <a
                 href="http://www.bundes-schuelerfirmen-contest.de/widget/voting/10470"
-                class="bg-yellow-500 text-yellow-900 font-bold mt-2 px-4 py-2 rounded-full text-xs uppercase"
-                >Zur der Abstimmung</a
+                class="bg-yellow-500 text-yellow-900 font-bold mt-2 sm:ml-2 px-4 py-2 rounded-full text-xs uppercase"
+                >Zur Abstimmung</a
               >
             </div>
             <div


### PR DESCRIPTION
## What's the reason? 🤔 
Last push's design updates weren't responsive, which caused an overlap of the button with the circular image on smaller screen devices (xs), like iPhone 6/7/8.

## What I've done 🔧 
+ Packed buttons in a responsive wrapper
+ added a responsive margin property to 2nd button
+ removed the circular image, mainly for two reasons:
  1. It crashes responsitivity because it's elevated from the site flow
  2. It looks cramped on mobile screens

## Before 
![image](https://user-images.githubusercontent.com/37245841/104429031-72cd4a80-5585-11eb-84f5-cec8b60731a7.png)
## After
![image](https://user-images.githubusercontent.com/37245841/104429128-8d072880-5585-11eb-9bd9-eded5a34c237.png)

_Solution may not be perfect - I'm open to suggestions._

FYI: @Maarcel56 :octocat: 